### PR TITLE
Add malli schema param for data validation

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps
- {}
+ {metosin/malli {:mvn/version "0.8.8"}}
  :aliases
  {:dev
   {:extra-paths ["test"]}


### PR DESCRIPTION
Closes #31
---
- Add an optional parameter `schema` to the api function `pullable/run`

To restrict access to some keys, the API owner can specify {closed true} in the schema so there should not be a need to add extra logic for that.