### PR TITLE
Basic client data and general pattern merging

### DIFF
--- a/src/sg/flybot/pullable/schema.clj
+++ b/src/sg/flybot/pullable/schema.clj
@@ -3,9 +3,7 @@
 
 (ns sg.flybot.pullable.schema
   "Pattern validation with Malli schema."
-  (:require [clojure.walk :refer [postwalk]]
-            [malli.core :as m]
-            [malli.util :as mu]))
+  (:require [malli.core :as m]))
 
 (defn lvar?
   [x]
@@ -31,7 +29,7 @@
    ::val      [:orn
                ::var
                [:nested [:ref ::pattern]]
-               [:filter [:or :int :double :boolean :keyword :uuid :string fn?]]]
+               [:filter :any]]
    ::vector   [:map-of ::key ::val]
    ::seq      [:cat
                ::vector
@@ -44,73 +42,49 @@
                ::vector
                ::seq]})
 
+(defn update-child
+  "Adds pattern info to the given schema `child` when applicable.
+   i.e. [:a {:min 1} :int] => [:a {:min 1} [:or ::var :int]]"
+  [child] 
+  (if (vector? child)
+    (let [[k o v] child
+          v       (if (m/schema? v) (m/form v) v)]
+      (cond
+        (some #{k} [:map :vector :sequential :set])
+        child
+
+        (and (vector? v) (sequential? (last v)))
+        child
+
+        :else
+        (if o
+          [k o [:or ::var v]]
+          [k [:or ::var v]])))
+    child))
+
+(defn combine-data-pattern
+  "Walks through the `data-schema` and updates it with pattern registry when applicable."
+  [data-schema]
+  (m/walk
+   (update-in data-schema [1 :registry] (fnil merge {}) general-pattern-registry)
+   (fn [schema _ children _]
+     (let [children (if (and (not= :schema (m/type schema))
+                             (vector? (m/form schema)))
+                      (map update-child children)
+                      children)]
+       (m/into-schema
+        (m/type schema) (m/properties schema) children (m/options schema))))))
+
 (defn pattern-validator
   "returns a function which can validate query pattern.
    - `data-schema`: user provided schema for data"
   ([data-schema]
    (m/validator
     (if data-schema
-      (throw (UnsupportedOperationException. "Not implemented yet"))
+      (combine-data-pattern data-schema)
       [:schema
        {:registry general-pattern-registry}
        ::pattern]))))
 
-(defn add-pattern
-  "Adds pattern info to the shcema element `el` when applicable."
-  [el]
-  (if (vector? el)
-    (let [[k v] el]
-      (cond
-        (some #{k} [:map :vector :sequential :set])
-        el
-
-       (and (vector? v) (sequential? (last v)))
-        el
-
-        :else
-        [k [:or ::var v]]))
-    el))
-
-(defn remove-malli-options
-  "Malli syntax contains optional maps such as [:map {:closed true} [:a :int]].
-   Removes the option map from the schema element `el`."
-  [el]
-  (if (and (vector? el) (map? (second el)))
-    (let [[a _ & r] el]
-      (vec (concat [a] r)))
-    el))
-
-(def pattern-registry
-  "Combinations of malli default registries and our custom registry."
-  (merge (m/default-schemas) (mu/schemas) general-pattern-registry))
-
-(defn merge-schemas
-  "Merges 2 schemas."
-  [sch1 sch2]
-  (m/deref
-   (m/schema
-    [:merge sch1 sch2]
-    {:registry pattern-registry})))
-
-(defn combine-data-pattern
-  "Enhances the given `data-schema` with the pattern schema.
-   The malli option maps are first removed to avoid being walked by the pattern.
-   Then the pattern schema is being combined with the data-schema.
-   Finally, the malli option maps are added back via merging with original data-schema."
-  [data-schema]
-  (merge-schemas 
-   data-schema
-   (->> data-schema
-        (postwalk remove-malli-options)
-        (postwalk add-pattern))))
-
 (comment
-  ((pattern-validator nil) '{:a ? (:b :with [3]) {:c ?a}})
-  (combine-data-pattern
-   [:map [:a :int] [:b :string]]) 
-
-  (m/validate
-   (combine-data-pattern
-    [:map [:a :int] [:b :string]])
-   {:a '?a :b "ok"}
-   {:registry pattern-registry}))
+  ((pattern-validator nil) '{:a 'a (:b :with [3]) {:c ?a}}))

--- a/src/sg/flybot/pullable/schema.clj
+++ b/src/sg/flybot/pullable/schema.clj
@@ -3,8 +3,9 @@
 
 (ns sg.flybot.pullable.schema
   "Pattern validation with Malli schema."
-  (:require
-   [malli.core :as m]))
+  (:require [clojure.walk :refer [postwalk]]
+            [malli.core :as m]
+            [malli.util :as mu]))
 
 (defn lvar?
   [x]
@@ -24,11 +25,13 @@
                [:k-with [:catn
                          [:k :keyword]
                          [:options [:* ::option]]]]]
+   ::var      [:orn
+               [:var   [:= '?]]
+               [:named [:fn lvar?]]]
    ::val      [:orn
-               [:var    [:= '?]]
-               [:named  [:fn lvar?]]
+               ::var
                [:nested [:ref ::pattern]]
-               [:filter :any]]
+               [:filter [:or :int :double :boolean :keyword :uuid :string fn?]]]
    ::vector   [:map-of ::key ::val]
    ::seq      [:cat
                ::vector
@@ -52,6 +55,62 @@
        {:registry general-pattern-registry}
        ::pattern]))))
 
+(defn add-pattern
+  "Adds pattern info to the shcema element `el` when applicable."
+  [el]
+  (if (vector? el)
+    (let [[k v] el]
+      (cond
+        (some #{k} [:map :vector :sequential :set])
+        el
+
+       (and (vector? v) (sequential? (last v)))
+        el
+
+        :else
+        [k [:or ::var v]]))
+    el))
+
+(defn remove-malli-options
+  "Malli syntax contains optional maps such as [:map {:closed true} [:a :int]].
+   Removes the option map from the schema element `el`."
+  [el]
+  (if (and (vector? el) (map? (second el)))
+    (let [[a _ & r] el]
+      (vec (concat [a] r)))
+    el))
+
+(def pattern-registry
+  "Combinations of malli default registries and our custom registry."
+  (merge (m/default-schemas) (mu/schemas) general-pattern-registry))
+
+(defn merge-schemas
+  "Merges 2 schemas."
+  [sch1 sch2]
+  (m/deref
+   (m/schema
+    [:merge sch1 sch2]
+    {:registry pattern-registry})))
+
+(defn combine-data-pattern
+  "Enhances the given `data-schema` with the pattern schema.
+   The malli option maps are first removed to avoid being walked by the pattern.
+   Then the pattern schema is being combined with the data-schema.
+   Finally, the malli option maps are added back via merging with original data-schema."
+  [data-schema]
+  (merge-schemas 
+   data-schema
+   (->> data-schema
+        (postwalk remove-malli-options)
+        (postwalk add-pattern))))
+
 (comment
-  ((pattern-validator nil) '{:a ? :b {:c ?a}})
-  )
+  ((pattern-validator nil) '{:a ? (:b :with [3]) {:c ?a}})
+  (combine-data-pattern
+   [:map [:a :int] [:b :string]]) 
+
+  (m/validate
+   (combine-data-pattern
+    [:map [:a :int] [:b :string]])
+   {:a '?a :b "ok"}
+   {:registry pattern-registry}))

--- a/src/sg/flybot/pullable/schema.clj
+++ b/src/sg/flybot/pullable/schema.clj
@@ -3,7 +3,8 @@
 
 (ns sg.flybot.pullable.schema
   "Pattern validation with Malli schema."
-  (:require [malli.core :as m]))
+  (:require [malli.core :as m]
+            [malli.util :as mu]))
 
 (defn lvar?
   [x]
@@ -43,48 +44,59 @@
                ::seq]})
 
 (defn update-child
-  "Adds pattern info to the given schema `child` when applicable.
+  "Adds pattern info to the given `child` when applicable.
+   `options` contains the required registries notably.
    i.e. [:a {:min 1} :int] => [:a {:min 1} [:or ::var :int]]"
-  [child] 
+  [child options]
   (if (vector? child)
-    (let [[k o v] child
-          v       (if (m/schema? v) (m/form v) v)]
-      (cond
-        (some #{k} [:map :vector :sequential :set])
+    (let [[k o v] child]
+      (if (or (some #{k} [:vector :sequential :set])
+              (mu/find-first v (fn [sch _ _] (= :map (m/type sch))) options))
         child
-
-        (and (vector? v) (sequential? (last v)))
-        child
-
-        :else
-        (if o
-          [k o [:or ::var v]]
-          [k [:or ::var v]])))
+        [k o [:or ::var v]]))
     child))
 
 (defn combine-data-pattern
   "Walks through the `data-schema` and updates it with pattern registry when applicable."
-  [data-schema]
+  [data-schema] 
   (m/walk
-   (update-in data-schema [1 :registry] (fnil merge {}) general-pattern-registry)
-   (fn [schema _ children _]
-     (let [children (if (and (not= :schema (m/type schema))
-                             (vector? (m/form schema)))
-                      (map update-child children)
+   data-schema
+   (fn [schema _ children options]
+     (let [children (if (m/children schema)
+                      (map #(update-child % options) children)
                       children)]
        (m/into-schema
-        (m/type schema) (m/properties schema) children (m/options schema))))))
+        (m/type schema) (m/properties schema) children options)))
+   (m/options data-schema)))
+
+(defn to-vector-syntax
+  "Takes a schema syntax and converts it to the vector syntax such as:
+   [:schema properties children]"
+  [syntax]
+  (let [v-schema (if (or (vector? syntax) (m/schema? syntax))
+                   (m/schema syntax)
+                   (m/from-ast syntax))]
+    (if (= :schema (m/type v-schema))
+      v-schema
+      [:schema nil v-schema])))
 
 (defn pattern-validator
   "returns a function which can validate query pattern.
    - `data-schema`: user provided schema for data"
-  ([data-schema]
-   (m/validator
-    (if data-schema
-      (combine-data-pattern data-schema)
-      [:schema
-       {:registry general-pattern-registry}
-       ::pattern]))))
+  [data-schema]
+  (m/validator
+   (if data-schema
+     (let [schema        (-> data-schema to-vector-syntax m/children first)
+           data-registry (-> data-schema m/properties :registry)]
+       (combine-data-pattern
+        [:schema
+         {:registry ((fnil merge {}) data-registry general-pattern-registry)}
+         [:and ::pattern schema]]))
+     [:schema
+      {:registry general-pattern-registry}
+      ::pattern])))
 
 (comment
-  ((pattern-validator nil) '{:a 'a (:b :with [3]) {:c ?a}}))
+  ((pattern-validator nil) '{:a ?a (:b :with [3]) {:c ?c}})
+  ((pattern-validator [:schema nil [:map [:a :int] [:b [:map [:c :string]]]]])
+   {:a '?a :b {:c '?c}}))

--- a/test/sg/flybot/pullable/schema_test.clj
+++ b/test/sg/flybot/pullable/schema_test.clj
@@ -1,69 +1,26 @@
 (ns sg.flybot.pullable.schema-test
   (:require [clojure.test :refer [is are deftest testing]]
-            [malli.util :as mu]
+            [malli.core :as m]
+            [malli.util :as mu] 
             [sg.flybot.pullable.schema :as sut]))
 
-
-(deftest pattern-validator
-  (testing "Pattern is valid so returns it."
-    (are [p] (true? ((sut/pattern-validator nil) p))
-    ;;basic patterns
-      '{:a ?}
-      '{:a ? :b ?}
-
-    ;;filtered
-      '{:a ? :b 1}
-
-    ;;filter with a function
-      {:a '? :b even?}
-
-    ;;guard clause
-      {(list :a :when even?) '?}
-
-    ;;guard with not-found
-      {(list :a :when even? :not-found 0) '?}
-
-    ;;with option 
-      '{(:a :with [3]) ?a}
-      '{(:a :with [{:b 2 :c 3}]) {:b ?}}
-
-    ;;seq query
-      '[{:a ?}]
-
-    ;;nested map query 
-      '{:a {:b ?}}
-      '{:a {:b [{:c ?}]}}
-
-    ;;named variable 
-      '{:a ?a}
-
-    ;;named variable join
-      '{:a ?x :b {:c ?x}}
-      '{:a ?x :b ?x}
-
-    ;;named join 
-      '{:a ?a :b ?a}
-
-    ;;capture a sequence 
-      '[{:a ? :b ?} ?g]
-
-    ;;seq option 
-      '[{:a ? :b ?} ? :seq [2 3]]
-
-    ;;batch option 
-      '{(:a :batch [[3] [{:ok 1}]]) ?a}))
-      (testing "data-schema provided conbined with pattern is valid."
-        (is (true? ((sut/pattern-validator
-                     [:schema
-                      {:registry {::test :int}}
-                      [:map [:a :int] [:b :string]]])
-                    {:a '?a :b "ok"})))))
+(deftest to-vector-syntax
+  (testing "Normal vector to schema vector."
+    (are [syntax] (mu/equals [:schema nil :int]
+                             (sut/to-vector-syntax syntax))
+      ;; vector syntax 
+      [:schema :int]
+      ;; schema vector syntax
+      (m/schema [:schema :int])
+      ;; schema map syntax
+      {:type :int})))
 
 (deftest combine-data-pattern
   (testing "Combines the data schema with the pattern registry."
     (are [sch-data sch-exp] (mu/equals
                              [:schema {:registry sut/general-pattern-registry} sch-exp]
-                             (sut/combine-data-pattern [:schema nil sch-data]))
+                             (sut/combine-data-pattern
+                              [:schema {:registry sut/general-pattern-registry} sch-data]))
       ;; simple map
       [:map [:a :int] [:b :string]]
       [:map [:a [:or ::sut/var :int]] [:b [:or ::sut/var :string]]]
@@ -80,6 +37,10 @@
       [:map [:a [:sequential :int]]]
       [:map [:a [:or ::sut/var [:sequential :int]]]]
 
+      ;; nested seq - not seq of pattern
+      [:map [:a [:sequential [:set [:vector :int]]]]]
+      [:map [:a [:or ::sut/var [:sequential [:set [:vector :int]]]]]]
+
       ;; simple seq
       [:map [:a [:sequential [:map [:b :int]]]]]
       [:map [:a [:sequential [:map [:b [:or ::sut/var :int]]]]]]
@@ -91,3 +52,71 @@
       [:vector
        [:map
         [:a [:set [:map [:b [:or ::sut/var :keyword]]]]]]])))
+
+(deftest pattern-validator
+  (testing "No data provided case: pattern is valid."
+    (are [p] (true? ((sut/pattern-validator nil) p))
+      ;;basic patterns
+      '{:a ?}
+      '{:a ? :b ?}
+
+      ;;filtered
+      '{:a ? :b 1}
+
+      ;;filter with a function
+      {:a '? :b even?}
+
+      ;;guard clause
+      {(list :a :when even?) '?}
+
+      ;;guard with not-found
+      {(list :a :when even? :not-found 0) '?}
+
+      ;;with option
+      '{(:a :with [3]) ?a}
+      '{(:a :with [{:b 2 :c 3}]) {:b ?}}
+
+      ;;seq query
+      '[{:a ?}]
+
+      ;;nested map query
+      '{:a {:b ?}}
+      '{:a {:b [{:c ?}]}}
+
+      ;;named variable
+      '{:a ?a}
+
+      ;;named variable join
+      '{:a ?x :b {:c ?x}}
+      '{:a ?x :b ?x}
+
+      ;;named join
+      '{:a ?a :b ?a}
+
+      ;;capture a sequence
+      '[{:a ? :b ?} ?g]
+
+      ;;seq option
+      '[{:a ? :b ?} ? :seq [2 3]]
+
+      ;;batch option
+      '{(:a :batch [[3] [{:ok 1}]]) ?a}))
+
+      (testing "data + pattern are valid."
+        (is (true? ((sut/pattern-validator
+                     [:schema 
+                      {:registry {::test :string}}
+                      [:map [:a :int] [:b ::test]]])
+                    {:a '?a :b "ok"}))))
+      (testing "data valid but pattern invalid."
+        (is (false? ((sut/pattern-validator
+                     [:schema
+                      {:registry {::test :string}}
+                      [:map [:a :int] [:b ::test]]])
+                    {:c '?c}))))
+      (testing "pattern valid but data invalid."
+        (is (false? ((sut/pattern-validator
+                      [:map [:a :int] [:b :int]])
+                    {:a '?a :b "ok"}))))
+      ;;TODO: data-schema does not work with options (:with, :seq etc)
+      )

--- a/test/sg/flybot/pullable/schema_test.clj
+++ b/test/sg/flybot/pullable/schema_test.clj
@@ -1,6 +1,5 @@
 (ns sg.flybot.pullable.schema-test
-  (:require [clojure.test :refer [are deftest testing]]
-            [malli.core :as m]
+  (:require [clojure.test :refer [is are deftest testing]]
             [malli.util :as mu]
             [sg.flybot.pullable.schema :as sut]))
 
@@ -52,13 +51,19 @@
       '[{:a ? :b ?} ? :seq [2 3]]
 
     ;;batch option 
-      '{(:a :batch [[3] [{:ok 1}]]) ?a})))
+      '{(:a :batch [[3] [{:ok 1}]]) ?a}))
+      (testing "data-schema provided conbined with pattern is valid."
+        (is (true? ((sut/pattern-validator
+                     [:schema
+                      {:registry {::test :int}}
+                      [:map [:a :int] [:b :string]]])
+                    {:a '?a :b "ok"})))))
 
 (deftest combine-data-pattern
   (testing "Combines the data schema with the pattern registry."
     (are [sch-data sch-exp] (mu/equals
-                             (m/schema sch-exp {:registry sut/pattern-registry})
-                             (sut/combine-data-pattern sch-data))
+                             [:schema {:registry sut/general-pattern-registry} sch-exp]
+                             (sut/combine-data-pattern [:schema nil sch-data]))
       ;; simple map
       [:map [:a :int] [:b :string]]
       [:map [:a [:or ::sut/var :int]] [:b [:or ::sut/var :string]]]
@@ -85,7 +90,4 @@
         [:a [:set [:map [:b :keyword]]]]]]
       [:vector
        [:map
-        [:a [:set [:map [:b [:or ::sut/var :keyword]]]]]]]
-
-      ;; TODO: options
-      )))
+        [:a [:set [:map [:b [:or ::sut/var :keyword]]]]]]])))


### PR DESCRIPTION
Closes #37
---

Combine client `data-schema` with our `general-pattern-schema` when applicable.

Cases covered so far:
- nested map or sequence of patterns
- malli option maps from client data not altered