### PR TITLE
Schema with client data

### DIFF
--- a/src/sg/flybot/pullable.clj
+++ b/src/sg/flybot/pullable.clj
@@ -41,32 +41,31 @@
        can have an optional variable and options. i.e., pattern 
        `'[{:a ?} ?]` on `[{:a 1} {:a 3} {}]` has a matching result of
        `[{:a 1} {:a 3} {}]`. "
-  [pattern]
-  (let [query-maker (core/query-maker)
-        q           (ptn/->query query-maker pattern ptn/filter-maker)]
-    (fn [data]
-      (core/run-bind q data))))
+  [pattern & [schema]]
+  (fn [data]
+    (let [p ((sch/pattern-validator schema) pattern)]
+      (if (:error p)
+        p
+        (let [query-maker (core/query-maker)
+              q           (ptn/->query query-maker pattern ptn/filter-maker)]
+          (core/run-bind q data))))))
 
 (defn run
   "Given `data`, validate and compile `pattern` if it has not been, run it, try to match with `data`.
    Returns a vector of matching result (same structure as data) and a map of logical
    variable bindings.
-   An optional malli `schema` can be provided to ensure the hape of the data to be pulled.
+   An optional malli `schema` can be provided to ensure the shape of the data to be pulled.
    Returns the error pattern if it is not valid."
   ([pattern data]
    (run pattern nil data))
   ([pattern schema data]
-   (let [pattern ((sch/pattern-validator schema) pattern)]
-     (if (:error pattern)
-       pattern
-       ((query pattern) data)))))
+   ((query pattern schema) data)))
 
 (comment
   (run '{:a ?} {:a 3 :b 2})
   (run '{:a 3 :b ?} {:a 3 :b 1})
-  (run '{:a ?a :b ?a} {:a 3 :b 2 :c 3}) 
+  (run '{:a ?a :b ?a} {:a 3 :b 2 :c 3})
   (run '{:a {:b ?}} {:a {:b 1 :c 2}})
   (run '{:a {:b {:c ?c}} :d {:e ?e}} {:a {:b {:c 5}} :d {:e 2}})
   (run '{:a ?x :b ?x} {:a 2 :b 3})
-  (run '[{(:a :not-found ::ok) ?} ?a] [{:a 1} {:a 3} {}])
-  )
+  (run '[{(:a :not-found ::ok) ?} ?a] [{:a 1} {:a 3} {}]))

--- a/src/sg/flybot/pullable.clj
+++ b/src/sg/flybot/pullable.clj
@@ -8,7 +8,8 @@
    information from data."
   (:require
    [sg.flybot.pullable.core :as core]
-   [sg.flybot.pullable.pattern :as ptn]))
+   [sg.flybot.pullable.pattern :as ptn]
+   [sg.flybot.pullable.schema :as sch]))
 
 ;;## Glue code 
 
@@ -47,11 +48,18 @@
       (core/run-bind q data))))
 
 (defn run
-  "Given `data`, compile `pattern` if it has not been, run it, try to match with `data`.
+  "Given `data`, validate and compile `pattern` if it has not been, run it, try to match with `data`.
    Returns a vector of matching result (same structure as data) and a map of logical
-   variable bindings."
+   variable bindings.
+   An optional malli `schema` can be provided to ensure the hape of the data to be pulled.
+   Returns the error pattern if it is not valid."
   ([pattern data]
-   ((query pattern) data)))
+   (run pattern nil data))
+  ([pattern schema data]
+   (let [pattern ((sch/pattern-validator schema) pattern)]
+     (if (:error pattern)
+       pattern
+       ((query pattern) data)))))
 
 (comment
   (run '{:a ?} {:a 3 :b 2})

--- a/src/sg/flybot/pullable/schema.clj
+++ b/src/sg/flybot/pullable/schema.clj
@@ -30,8 +30,13 @@
                [:nested [:ref ::pattern]]
                [:filter :any]]
    ::vector   [:map-of ::key ::val]
-   ::seq      [:vector
-               [:ref ::pattern]]
+   ::seq      [:cat
+               ::vector
+               [:?
+                [:alt
+                 [:= '?]
+                 [:fn lvar?]]]
+               [:* ::option]]
    ::pattern  [:or
                ::vector
                ::seq]})

--- a/src/sg/flybot/pullable/schema.clj
+++ b/src/sg/flybot/pullable/schema.clj
@@ -3,9 +3,7 @@
 
 (ns sg.flybot.pullable.schema
   "Pattern validation with Malli schema."
-  (:require [clojure.walk :refer [postwalk]]
-            [malli.core :as m]
-            [malli.util :as mu]))
+  (:require [malli.core :as m]))
 
 (defn lvar?
   [x]
@@ -31,7 +29,7 @@
    ::val      [:orn
                ::var
                [:nested [:ref ::pattern]]
-               [:filter [:or :int :double :boolean :keyword :uuid :string fn?]]]
+               [:filter :any]]
    ::vector   [:map-of ::key ::val]
    ::seq      [:cat
                ::vector
@@ -44,73 +42,49 @@
                ::vector
                ::seq]})
 
+(defn update-child
+  "Adds pattern info to the given schema `child` when applicable.
+   i.e. [:a {:min 1} :int] => [:a {:min 1} [:or ::var :int]]"
+  [child] 
+  (if (vector? child)
+    (let [[k o v] child
+          v       (if (m/schema? v) (m/form v) v)]
+      (cond
+        (some #{k} [:map :vector :sequential :set])
+        child
+
+        (and (vector? v) (sequential? (last v)))
+        child
+
+        :else
+        (if o
+          [k o [:or ::var v]]
+          [k [:or ::var v]])))
+    child))
+
+(defn combine-data-pattern
+  "Walks through the `data-schema` and updates it with pattern registry when applicable."
+  [data-schema]
+  (m/walk
+   (update-in data-schema [1 :registry] (fnil merge {}) general-pattern-registry)
+   (fn [schema _ children _]
+     (let [children (if (and (not= :schema (m/type schema))
+                             (vector? (m/form schema)))
+                      (map update-child children)
+                      children)]
+       (m/into-schema
+        (m/type schema) (m/properties schema) children (m/options schema))))))
+
 (defn pattern-validator
   "returns a function which can validate query pattern.
    - `data-schema`: user provided schema for data"
   ([data-schema]
    (m/validator
     (if data-schema
-      (throw (UnsupportedOperationException. "Not implemented yet"))
+      (combine-data-pattern data-schema)
       [:schema
        {:registry general-pattern-registry}
        ::pattern]))))
 
-(defn add-pattern
-  "Adds pattern info to the shcema element `el` when applicable."
-  [el]
-  (if (vector? el)
-    (let [[k v] el]
-      (cond
-        (some #{k} [:map :vector :sequential :set])
-        el
-
-       (and (vector? v) (sequential? (last v)))
-        el
-
-        :else
-        [k [:or ::var v]]))
-    el))
-
-(defn remove-malli-options
-  "Malli syntax contains optional maps such as [:map {:closed true} [:a :int]].
-   Removes the option map from the schema element `el`."
-  [el]
-  (if (and (vector? el) (map? (second el)))
-    (let [[a _ & r] el]
-      (vec (concat [a] r)))
-    el))
-
-(def pattern-registry
-  "Combinations of malli default registries and our custom registry."
-  (merge (m/default-schemas) (mu/schemas) general-pattern-registry))
-
-(defn merge-schemas
-  "Merges 2 schemas."
-  [sch1 sch2]
-  (m/deref
-   (m/schema
-    [:merge sch1 sch2]
-    {:registry pattern-registry})))
-
-(defn combine-data-pattern
-  "Enhances the given `data-schema` with the pattern schema.
-   The malli option maps are first removed to avoid being walked by the pattern.
-   Then the pattern schema is being combined with the data-schema.
-   Finally, the malli option maps are added back via merging with original data-schema."
-  [data-schema]
-  (merge-schemas 
-   data-schema
-   (->> data-schema
-        (postwalk remove-malli-options)
-        (postwalk add-pattern))))
-
 (comment
-  ((pattern-validator nil) '{:a ? (:b :with [3]) {:c ?a}})
-  (combine-data-pattern
-   [:map [:a :int] [:b :string]]) 
-
-  (m/validate
-   (combine-data-pattern
-    [:map [:a :int] [:b :string]])
-   {:a '?a :b "ok"}
-   {:registry pattern-registry}))
+  ((pattern-validator nil) '{:a 'a (:b :with [3]) {:c ?a}}))

--- a/src/sg/flybot/pullable/schema.clj
+++ b/src/sg/flybot/pullable/schema.clj
@@ -161,19 +161,21 @@
    - general pattern schema: generic validation (options in keys, selectors formats etc.)
    - client pattern schema: when `data-schema` is provided, runs furhter validations combining the data and pattern format when applicable
    (proper keys, proper filters, etc.)
-   The function returns the pattern if it is valid, else returns ex-info."
+   The function returns the pattern if it is valid, else returns pure malli error."
   [data-schema]
   (fn [pattern] 
     (cond
       (not (general-pattern-validator pattern))
-      (ex-info "error in pattern syntax"
-               {:err-type :general-pattern-syntax
-                :err      (mu/explain-data general-pattern-schema pattern)})
+      {:error {:cause     "Invalid general pattern syntax"
+               :type      :general-pattern-syntax
+               :malli-err (mu/explain-data general-pattern-schema pattern)}}
+
       (and data-schema
            (not ((client-pattern-validator data-schema) pattern)))
-      (ex-info "error in pattern query"
-               {:err-type :client-pattern-data
-                :err      (mu/explain-data data-schema (m/encode data-schema pattern keys-transformer))})
+      {:error {:cause     "Invalid client pattern data"
+               :type      :client-pattern-data
+               :malli-err (mu/explain-data data-schema (m/encode data-schema pattern keys-transformer))}}
+
       :else
       pattern)))
 

--- a/src/sg/flybot/pullable/schema.clj
+++ b/src/sg/flybot/pullable/schema.clj
@@ -3,8 +3,9 @@
 
 (ns sg.flybot.pullable.schema
   "Pattern validation with Malli schema."
-  (:require
-   [malli.core :as m]))
+  (:require [clojure.walk :refer [postwalk]]
+            [malli.core :as m]
+            [malli.util :as mu]))
 
 (defn lvar?
   [x]
@@ -24,11 +25,13 @@
                [:k-with [:catn
                          [:k :keyword]
                          [:options [:* ::option]]]]]
+   ::var      [:orn
+               [:var   [:= '?]]
+               [:named [:fn lvar?]]]
    ::val      [:orn
-               [:var    [:= '?]]
-               [:named  [:fn lvar?]]
+               ::var
                [:nested [:ref ::pattern]]
-               [:filter :any]]
+               [:filter [:or :int :double :boolean :keyword :uuid :string fn?]]]
    ::vector   [:map-of ::key ::val]
    ::seq      [:cat
                ::vector
@@ -52,6 +55,62 @@
        {:registry general-pattern-registry}
        ::pattern]))))
 
+(defn add-pattern
+  "Adds pattern info to the shcema element `el` when applicable."
+  [el]
+  (if (vector? el)
+    (let [[k v] el]
+      (cond
+        (some #{k} [:map :vector :sequential :set])
+        el
+
+       (and (vector? v) (sequential? (last v)))
+        el
+
+        :else
+        [k [:or ::var v]]))
+    el))
+
+(defn remove-malli-options
+  "Malli syntax contains optional maps such as [:map {:closed true} [:a :int]].
+   Removes the option map from the schema element `el`."
+  [el]
+  (if (and (vector? el) (map? (second el)))
+    (let [[a _ & r] el]
+      (vec (concat [a] r)))
+    el))
+
+(def pattern-registry
+  "Combinations of malli default registries and our custom registry."
+  (merge (m/default-schemas) (mu/schemas) general-pattern-registry))
+
+(defn merge-schemas
+  "Merges 2 schemas."
+  [sch1 sch2]
+  (m/deref
+   (m/schema
+    [:merge sch1 sch2]
+    {:registry pattern-registry})))
+
+(defn combine-data-pattern
+  "Enhances the given `data-schema` with the pattern schema.
+   The malli option maps are first removed to avoid being walked by the pattern.
+   Then the pattern schema is being combined with the data-schema.
+   Finally, the malli option maps are added back via merging with original data-schema."
+  [data-schema]
+  (merge-schemas 
+   data-schema
+   (->> data-schema
+        (postwalk remove-malli-options)
+        (postwalk add-pattern))))
+
 (comment
-  ((pattern-validator nil) '{:a ? :b {:c ?a}})
-  )
+  ((pattern-validator nil) '{:a ? (:b :with [3]) {:c ?a}})
+  (combine-data-pattern
+   [:map [:a :int] [:b :string]]) 
+
+  (m/validate
+   (combine-data-pattern
+    [:map [:a :int] [:b :string]])
+   {:a '?a :b "ok"}
+   {:registry pattern-registry}))

--- a/src/sg/flybot/pullable/schema.clj
+++ b/src/sg/flybot/pullable/schema.clj
@@ -3,86 +3,50 @@
 
 (ns sg.flybot.pullable.schema
   "Pattern validation with Malli schema."
-  (:require [clojure.walk :refer [postwalk]]
-            [malli.core :as m]
-            [malli.error :as me]
-            [malli.util :as mu]))
+  (:require
+   [malli.core :as m]))
 
-(defn valid-symbol?
-  "Returns true if `p` is a lvar or ?"
-  [p]
-  (and (symbol? p) (re-matches #"\?.*" (name p))))
+(defn lvar?
+  [x]
+  (and (symbol? x) (re-matches #"\?.*" (str x))))
 
-(defn transform-key
-  "Adapts map keys formats to make it malli schema friendly.
-   i.e. (:a :when even? :not-found 0) => [[:a nil] [:when odd?] [:not-found 0]]."
-  [mk]
-  (let [[k & opts] (if (sequential? mk) mk [mk])]
-    (->> (concat [k nil] opts)
-         (partition 2)
-         (map vec)
-         (into []))))
+(def general-pattern-registry
+  "general schema registry"
+  {::option   [:alt
+               [:cat [:= :default] :any]
+               [:cat [:= :not-found] :any]
+               [:cat [:= :when] fn?]
+               [:cat [:= :seq] vector?]
+               [:cat [:= :with] vector?]
+               [:cat [:= :batch] vector?]]
+   ::key      [:orn
+               [:k :keyword]
+               [:k-with [:catn
+                         [:k :keyword]
+                         [:options [:* ::option]]]]]
+   ::val      [:orn
+               [:var    [:= '?]]
+               [:named  [:fn lvar?]]
+               [:nested [:ref ::pattern]]
+               [:filter :any]]
+   ::vector   [:map-of ::key ::val]
+   ::seq      [:vector
+               [:ref ::pattern]]
+   ::pattern  [:or
+               ::vector
+               ::seq]})
 
-(defn transform-all-keys
-  "Recursively transforms all map keys to malli friendly keys."
-  [m]
-  (let [f (fn [[k v]] [(transform-key k) v])]
-    ;; only apply to maps
-    (postwalk (fn [x] (if (map? x)
-                        (into {} (map f x))
-                        x))
-              m)))
-
-(def sch-pattern-keys
-  "Malli schema for the different post-processors in the keys.
-   Expects individual post-processors with format [proc arg]
-   i.e. [:not-found 0]"
-  [:multi {:dispatch first}
-   [:when [:tuple [:= :when] fn?]]
-   [:not-found [:tuple [:= :not-found] :any]]
-   [:with [:tuple [:= :with] vector?]]
-   [:batch [:tuple [:= :batch] [:vector vector?]]]
-   [:watch [:tuple [:= :watch] fn?]]
-   [::m/default [:tuple :keyword :nil]]])
-
-(defn sch-pattern-seq
-  "Malli schema for the pattern eventually inside seq."
-  [pattern]
-  [:or 
-    pattern 
-    [:tuple pattern]
-    [:tuple pattern [:maybe [:fn valid-symbol?]]]
-    [:tuple pattern [:fn valid-symbol?] [:= :seq] [:sequential any?]]])
-
-(def sch-pattern
-  "Malli schema for the pattern."
-  [:schema
-   {:registry
-    {::pattern
-     [:map-of
-      [:vector sch-pattern-keys]
-      [:or 
-       [:fn valid-symbol?] ;; '? or '?x 
-       [:fn #(not (sequential? %))] ;; filters
-       (sch-pattern-seq [:ref ::pattern])]]}}
-   (sch-pattern-seq ::pattern)])
-
-(defn validate-pattern
-  "Runs the `pattern` against the malli schema.
-   The pattern keys are first modified to allow malli schema validation.
-   Returns the `pattern` if pattern is valid, else throws error."
-  [pattern]
-  (let [validator        (m/validator sch-pattern)
-        pattern-new-keys (transform-all-keys pattern)]
-    (if (validator pattern-new-keys)
-      pattern
-      (throw
-       (let [err (mu/explain-data sch-pattern pattern-new-keys)]
-         (ex-info (str (me/humanize err))
-                  {:pattern          pattern
-                   :pattern-new-keys pattern-new-keys
-                   :error            err}))))))
+(defn pattern-validator
+  "returns a function which can validate query pattern.
+   - `data-schema`: user provided schema for data"
+  ([data-schema]
+   (m/validator
+    (if data-schema
+      (throw (UnsupportedOperationException. "Not implemented yet"))
+      [:schema
+       {:registry general-pattern-registry}
+       ::pattern]))))
 
 (comment
-  (m/validate sch-pattern {[[:a nil] [:not-found 3] [:when odd?]] '?})
-  (validate-pattern [{(list :a :not-found 3 :when odd?) '?}]))
+  ((pattern-validator nil) '{:a ? :b {:c ?a}})
+  )

--- a/src/sg/flybot/pullable/schema.clj
+++ b/src/sg/flybot/pullable/schema.clj
@@ -3,7 +3,8 @@
 
 (ns sg.flybot.pullable.schema
   "Pattern validation with Malli schema."
-  (:require [malli.core :as m]))
+  (:require [malli.core :as m]
+            [malli.util :as mu]))
 
 (defn lvar?
   [x]
@@ -43,48 +44,59 @@
                ::seq]})
 
 (defn update-child
-  "Adds pattern info to the given schema `child` when applicable.
+  "Adds pattern info to the given `child` when applicable.
+   `options` contains the required registries notably.
    i.e. [:a {:min 1} :int] => [:a {:min 1} [:or ::var :int]]"
-  [child] 
+  [child options]
   (if (vector? child)
-    (let [[k o v] child
-          v       (if (m/schema? v) (m/form v) v)]
-      (cond
-        (some #{k} [:map :vector :sequential :set])
+    (let [[k o v] child]
+      (if (or (some #{k} [:vector :sequential :set])
+              (mu/find-first v (fn [sch _ _] (= :map (m/type sch))) options))
         child
-
-        (and (vector? v) (sequential? (last v)))
-        child
-
-        :else
-        (if o
-          [k o [:or ::var v]]
-          [k [:or ::var v]])))
+        [k o [:or ::var v]]))
     child))
 
 (defn combine-data-pattern
   "Walks through the `data-schema` and updates it with pattern registry when applicable."
-  [data-schema]
+  [data-schema] 
   (m/walk
-   (update-in data-schema [1 :registry] (fnil merge {}) general-pattern-registry)
-   (fn [schema _ children _]
-     (let [children (if (and (not= :schema (m/type schema))
-                             (vector? (m/form schema)))
-                      (map update-child children)
+   data-schema
+   (fn [schema _ children options]
+     (let [children (if (m/children schema)
+                      (map #(update-child % options) children)
                       children)]
        (m/into-schema
-        (m/type schema) (m/properties schema) children (m/options schema))))))
+        (m/type schema) (m/properties schema) children options)))
+   (m/options data-schema)))
+
+(defn to-vector-syntax
+  "Takes a schema syntax and converts it to the vector syntax such as:
+   [:schema properties children]"
+  [syntax]
+  (let [v-schema (if (or (vector? syntax) (m/schema? syntax))
+                   (m/schema syntax)
+                   (m/from-ast syntax))]
+    (if (= :schema (m/type v-schema))
+      v-schema
+      [:schema nil v-schema])))
 
 (defn pattern-validator
   "returns a function which can validate query pattern.
    - `data-schema`: user provided schema for data"
-  ([data-schema]
-   (m/validator
-    (if data-schema
-      (combine-data-pattern data-schema)
-      [:schema
-       {:registry general-pattern-registry}
-       ::pattern]))))
+  [data-schema]
+  (m/validator
+   (if data-schema
+     (let [schema        (-> data-schema to-vector-syntax m/children first)
+           data-registry (-> data-schema m/properties :registry)]
+       (combine-data-pattern
+        [:schema
+         {:registry ((fnil merge {}) data-registry general-pattern-registry)}
+         [:and ::pattern schema]]))
+     [:schema
+      {:registry general-pattern-registry}
+      ::pattern])))
 
 (comment
-  ((pattern-validator nil) '{:a 'a (:b :with [3]) {:c ?a}}))
+  ((pattern-validator nil) '{:a ?a (:b :with [3]) {:c ?c}})
+  ((pattern-validator [:schema nil [:map [:a :int] [:b [:map [:c :string]]]]])
+   {:a '?a :b {:c '?c}}))

--- a/src/sg/flybot/pullable/schema.clj
+++ b/src/sg/flybot/pullable/schema.clj
@@ -7,9 +7,36 @@
             [malli.util :as mu]
             [malli.transform :as mt]))
 
+;;; Internal utility functions
+
 (defn lvar?
   [x]
   (and (symbol? x) (re-matches #"\?.*" (str x))))
+
+(defn to-vector-syntax
+  "Takes a schema syntax and converts it to the vector syntax such as:
+   [:schema properties children]"
+  [syntax]
+  (let [v-schema (if (or (vector? syntax) (m/schema? syntax))
+                   (m/schema syntax)
+                   (m/from-ast syntax))]
+    (if (= :schema (m/type v-schema))
+      v-schema
+      [:schema nil v-schema])))
+
+(defn normalize-properties
+  "Walk the schema and make sure all subschemas respect the format:
+   [type properties & children]
+   by adding nil for properties when not specified."
+  [schema]
+  (m/walk
+   schema
+   (fn [schema _ children _]
+     (if (vector? (m/form schema))
+       (into [(m/type schema) (m/properties schema)] children)
+       (m/form schema)))))
+
+;;; General pattern
 
 (def general-pattern-registry
   "general schema registry"
@@ -33,29 +60,57 @@
                [:nested [:ref ::pattern]]
                [:filter :any]]
    ::vector   [:map-of ::key ::val]
-   ::seq      [:cat
-               ::vector
+   ::seq-args [:cat 
                [:?
                 [:alt
                  [:= '?]
                  [:fn lvar?]]]
                [:* ::option]]
+   ::seq      [:cat
+               ::vector
+               ::seq-args]
    ::pattern  [:or
                ::vector
                ::seq]})
+
+(def general-pattern-validator
+  (m/validator
+   [:schema
+    {:registry general-pattern-registry}
+    ::pattern]))
+
+;;; Client pattern
 
 (defn update-child
   "Adds pattern info to the given `child` when applicable.
    `options` contains the required registries notably.
    i.e. [:a {:min 1} :int] => [:a {:min 1} [:or ::var :int]]"
-  [child options]
-  (if (vector? child)
-    (let [[k o v] child]
-      (if (or (some #{k} [:vector :sequential :set])
-              (mu/find-first v (fn [sch _ _] (= :map (m/type sch))) options))
-        child
-        [k o [:or ::var v]]))
-    child))
+  [child options] 
+  (let [child (if (m/schema? child)
+                (-> child normalize-properties)
+                child)]
+    (if (vector? child)
+      (let [[k o & v] child
+            v1 (if (m/schema? (first v)) (normalize-properties (first v)) (first v))] 
+        (cond
+          (and (vector? v1)
+               (some #{(first v1)} [:vector :sequential :set])
+               (mu/find-first v1 (fn [sch _ _] (= :map (m/type sch))) options))
+          [k o [:or v1 [:cat (last v1) ::seq-args]]]
+
+          (and (some #{k} [:vector :sequential :set])
+               (mu/find-first v1 (fn [sch _ _] (= :map (m/type sch))) options))
+          [:or child [:cat v1 ::seq-args]]
+
+          (some #{k} [:map :vector :sequential :set])
+          child
+
+          (mu/find-first v1 (fn [sch _ _] (= :map (m/type sch))) options)
+          child
+
+          :else
+          [k o [:or ::var v1]]))
+      child)))
 
 (defn combine-data-pattern
   "Walks through the `data-schema` and updates it with pattern registry when applicable."
@@ -70,25 +125,8 @@
         (m/type schema) (m/properties schema) children options)))
    (m/options data-schema)))
 
-(defn to-vector-syntax
-  "Takes a schema syntax and converts it to the vector syntax such as:
-   [:schema properties children]"
-  [syntax]
-  (let [v-schema (if (or (vector? syntax) (m/schema? syntax))
-                   (m/schema syntax)
-                   (m/from-ast syntax))]
-    (if (= :schema (m/type v-schema))
-      v-schema
-      [:schema nil v-schema])))
-
-(def general-pattern-validator
-  (m/validator
-   [:schema
-    {:registry general-pattern-registry}
-    ::pattern]))
-
 (defn keys-decoder
-  "Transform pattern's keys into simple keyword keys against the data-schema.
+  "Transforms pattern's keys into simple keyword keys against the data-schema.
    i.e. {'(:a :with [3]) '?a} => {:a '?a}"
   [data-schema]
   (m/encoder
@@ -106,6 +144,8 @@
        {:registry ((fnil merge {}) data-registry general-pattern-registry)}
        inner-schema]))))
 
+;;; Validator of pattern
+
 (defn pattern-validator
   "Returns a function which can validate a query pattern.
    Validates pattern agains 2 schemas:
@@ -117,7 +157,7 @@
     (let [decoder       (keys-decoder data-schema)
           validator     (and general-pattern-validator
                              (client-pattern-validator data-schema))]
-      (fn [pattern] (->> pattern decoder validator)))
+      (comp validator decoder))
     general-pattern-validator))
 
 (comment

--- a/test/sg/flybot/pullable/schema_test.clj
+++ b/test/sg/flybot/pullable/schema_test.clj
@@ -1,69 +1,26 @@
 (ns sg.flybot.pullable.schema-test
   (:require [clojure.test :refer [is are deftest testing]]
-            [malli.util :as mu]
+            [malli.core :as m]
+            [malli.util :as mu] 
             [sg.flybot.pullable.schema :as sut]))
 
-
-(deftest pattern-validator
-  (testing "Pattern is valid so returns it."
-    (are [p] (true? ((sut/pattern-validator nil) p))
-    ;;basic patterns
-      '{:a ?}
-      '{:a ? :b ?}
-
-    ;;filtered
-      '{:a ? :b 1}
-
-    ;;filter with a function
-      {:a '? :b even?}
-
-    ;;guard clause
-      {(list :a :when even?) '?}
-
-    ;;guard with not-found
-      {(list :a :when even? :not-found 0) '?}
-
-    ;;with option 
-      '{(:a :with [3]) ?a}
-      '{(:a :with [{:b 2 :c 3}]) {:b ?}}
-
-    ;;seq query
-      '[{:a ?}]
-
-    ;;nested map query 
-      '{:a {:b ?}}
-      '{:a {:b [{:c ?}]}}
-
-    ;;named variable 
-      '{:a ?a}
-
-    ;;named variable join
-      '{:a ?x :b {:c ?x}}
-      '{:a ?x :b ?x}
-
-    ;;named join 
-      '{:a ?a :b ?a}
-
-    ;;capture a sequence 
-      '[{:a ? :b ?} ?g]
-
-    ;;seq option 
-      '[{:a ? :b ?} ? :seq [2 3]]
-
-    ;;batch option 
-      '{(:a :batch [[3] [{:ok 1}]]) ?a}))
-      (testing "data-schema provided conbined with pattern is valid."
-        (is (true? ((sut/pattern-validator
-                     [:schema
-                      {:registry {::test :int}}
-                      [:map [:a :int] [:b :string]]])
-                    {:a '?a :b "ok"})))))
+(deftest to-vector-syntax
+  (testing "Normal vector to schema vector."
+    (are [syntax] (mu/equals [:schema nil :int]
+                             (sut/to-vector-syntax syntax))
+      ;; vector syntax 
+      [:schema :int]
+      ;; schema vector syntax
+      (m/schema [:schema :int])
+      ;; schema map syntax
+      {:type :int})))
 
 (deftest combine-data-pattern
   (testing "Combines the data schema with the pattern registry."
     (are [sch-data sch-exp] (mu/equals
                              [:schema {:registry sut/general-pattern-registry} sch-exp]
-                             (sut/combine-data-pattern [:schema nil sch-data]))
+                             (sut/combine-data-pattern
+                              [:schema {:registry sut/general-pattern-registry} sch-data]))
       ;; simple map
       [:map [:a :int] [:b :string]]
       [:map [:a [:or ::sut/var :int]] [:b [:or ::sut/var :string]]]
@@ -80,6 +37,10 @@
       [:map [:a [:sequential :int]]]
       [:map [:a [:or ::sut/var [:sequential :int]]]]
 
+      ;; nested seq - not seq of pattern
+      [:map [:a [:sequential [:set [:vector :int]]]]]
+      [:map [:a [:or ::sut/var [:sequential [:set [:vector :int]]]]]]
+
       ;; simple seq
       [:map [:a [:sequential [:map [:b :int]]]]]
       [:map [:a [:sequential [:map [:b [:or ::sut/var :int]]]]]]
@@ -91,3 +52,71 @@
       [:vector
        [:map
         [:a [:set [:map [:b [:or ::sut/var :keyword]]]]]]])))
+
+(deftest pattern-validator
+  (testing "No data provided case: pattern is valid."
+    (are [p] (true? ((sut/pattern-validator nil) p))
+      ;;basic patterns
+      '{:a ?}
+      '{:a ? :b ?}
+
+      ;;filtered
+      '{:a ? :b 1}
+
+      ;;filter with a function
+      {:a '? :b even?}
+
+      ;;guard clause
+      {(list :a :when even?) '?}
+
+      ;;guard with not-found
+      {(list :a :when even? :not-found 0) '?}
+
+      ;;with option
+      '{(:a :with [3]) ?a}
+      '{(:a :with [{:b 2 :c 3}]) {:b ?}}
+
+      ;;seq query
+      '[{:a ?}]
+
+      ;;nested map query
+      '{:a {:b ?}}
+      '{:a {:b [{:c ?}]}}
+
+      ;;named variable
+      '{:a ?a}
+
+      ;;named variable join
+      '{:a ?x :b {:c ?x}}
+      '{:a ?x :b ?x}
+
+      ;;named join
+      '{:a ?a :b ?a}
+
+      ;;capture a sequence
+      '[{:a ? :b ?} ?g]
+
+      ;;seq option
+      '[{:a ? :b ?} ? :seq [2 3]]
+
+      ;;batch option
+      '{(:a :batch [[3] [{:ok 1}]]) ?a}))
+
+      (testing "data + pattern are valid."
+        (is (true? ((sut/pattern-validator
+                     [:schema 
+                      {:registry {::test :string}}
+                      [:map [:a :int] [:b ::test]]])
+                    {:a '?a :b "ok"}))))
+      (testing "data valid but pattern invalid."
+        (is (false? ((sut/pattern-validator
+                     [:schema
+                      {:registry {::test :string}}
+                      [:map [:a :int] [:b ::test]]])
+                    {:c '?c}))))
+      (testing "pattern valid but data invalid."
+        (is (false? ((sut/pattern-validator
+                      [:map [:a :int] [:b :int]])
+                    {:a '?a :b "ok"}))))
+      ;;TODO: data-schema does not work with options (:with, :seq etc)
+      )

--- a/test/sg/flybot/pullable/schema_test.clj
+++ b/test/sg/flybot/pullable/schema_test.clj
@@ -149,7 +149,7 @@
              ((sut/pattern-validator data-schema) {:a '?a :b "ok"}))))
     (testing "data valid but pattern invalid."
       (is (= :general-pattern-syntax
-           (-> {'(:a :wrong-option [3]) '?a} ((sut/pattern-validator data-schema)) ex-data :err-type))))
+           (-> {'(:a :wrong-option [3]) '?a} ((sut/pattern-validator data-schema)) :error :type))))
     (testing "pattern valid but data invalid."
       (is (= :client-pattern-data
-           (-> {:a '?a :b :ko} ((sut/pattern-validator data-schema)) ex-data :err-type))))))
+           (-> {:a '?a :b :ko} ((sut/pattern-validator data-schema)) :error :type))))))

--- a/test/sg/flybot/pullable/schema_test.clj
+++ b/test/sg/flybot/pullable/schema_test.clj
@@ -1,6 +1,5 @@
 (ns sg.flybot.pullable.schema-test
-  (:require [clojure.test :refer [are deftest testing]]
-            [malli.core :as m]
+  (:require [clojure.test :refer [is are deftest testing]]
             [malli.util :as mu]
             [sg.flybot.pullable.schema :as sut]))
 
@@ -52,13 +51,19 @@
       '[{:a ? :b ?} ? :seq [2 3]]
 
     ;;batch option 
-      '{(:a :batch [[3] [{:ok 1}]]) ?a})))
+      '{(:a :batch [[3] [{:ok 1}]]) ?a}))
+      (testing "data-schema provided conbined with pattern is valid."
+        (is (true? ((sut/pattern-validator
+                     [:schema
+                      {:registry {::test :int}}
+                      [:map [:a :int] [:b :string]]])
+                    {:a '?a :b "ok"})))))
 
 (deftest combine-data-pattern
   (testing "Combines the data schema with the pattern registry."
     (are [sch-data sch-exp] (mu/equals
-                             (m/schema sch-exp {:registry sut/pattern-registry})
-                             (sut/combine-data-pattern sch-data))
+                             [:schema {:registry sut/general-pattern-registry} sch-exp]
+                             (sut/combine-data-pattern [:schema nil sch-data]))
       ;; simple map
       [:map [:a :int] [:b :string]]
       [:map [:a [:or ::sut/var :int]] [:b [:or ::sut/var :string]]]
@@ -85,7 +90,4 @@
         [:a [:set [:map [:b :keyword]]]]]]
       [:vector
        [:map
-        [:a [:set [:map [:b [:or ::sut/var :keyword]]]]]]]
-
-      ;; TODO: options
-      )))
+        [:a [:set [:map [:b [:or ::sut/var :keyword]]]]]]])))

--- a/test/sg/flybot/pullable/schema_test.clj
+++ b/test/sg/flybot/pullable/schema_test.clj
@@ -1,32 +1,12 @@
 (ns sg.flybot.pullable.schema-test
   (:require
    [sg.flybot.pullable.schema :as sut]
-   [clojure.test :refer [deftest are testing is]])
-(:import
- [clojure.lang ExceptionInfo]))
+   [clojure.test :refer [deftest are testing]]))
 
-(deftest transform-key
-  (testing "Converts the keyword to a vector of vectors"
-    (is (= [[:a nil]]
-           (sut/transform-key :a))))
-  (testing "Converts the list to a vector of vectors"
-    (is (= [[:a nil] [:when even?] [:not-found 0]]
-           (sut/transform-key (list :a :when even? :not-found 0))))))
-
-(deftest transform-all-keys
-  (testing "Converts all the keys of the maps to vector of vectors."
-    (is (= [{[[:a nil] [:not-found 3] [:when odd?]] '?
-             [[:b nil] [:with [3]]] {[[:c nil] [:when odd?]] '?c [[:d nil]] even?}}]
-           (sut/transform-all-keys
-            [{(list :a :not-found 3 :when odd?) '?
-              '(:b :with [3]) {(list :c :when odd?) '?c :d even?}}])))))
 
 (deftest pattern-valid?
-  (testing "Pattern is wrong so throws error."
-    (is (thrown? ExceptionInfo (sut/validate-pattern {:a '? :b []})))
-    (is (thrown? ExceptionInfo (sut/validate-pattern '[{:a 3} :with [3]]))))
   (testing "Pattern is valid so returns it."
-    (are [p] (= p (sut/validate-pattern p))
+    (are [p] (true? ((sut/pattern-validator nil) p))
     ;;basic patterns
       '{:a ?}
       '{:a ? :b ?}

--- a/test/sg/flybot/pullable_test.clj
+++ b/test/sg/flybot/pullable_test.clj
@@ -8,75 +8,81 @@
     (is (= [{:a 1} nil] ((sut/query '{:a ?}) {:a 1})))))
 
 (deftest ^:integrated run
-  (are [data x exp] (= exp (sut/run x data))
-    ;;basic patterns
-    {:a 1}           '{:a ?}        [{:a 1} nil]
-    {:a 1 :b 2 :c 3} '{:a ? :b ?}   [{:a 1 :b 2} nil]
+  (testing "Pattern is valid and pull the expected data."
+    (are [data x exp] (= exp (sut/run x data))
+      ;;basic patterns
+      {:a 1}           '{:a ?}        [{:a 1} nil]
+      {:a 1 :b 2 :c 3} '{:a ? :b ?}   [{:a 1 :b 2} nil]
 
-    ;;filtered
-    {:a 1 :b 2}      '{:a ? :b 1}   [nil nil]
+      ;;filtered
+      {:a 1 :b 2}      '{:a ? :b 1}   [nil nil]
 
-    ;;filter with a function
-    {:a 8 :b 2}      {:a '? :b even?} [{:a 8} nil]
+      ;;filter with a function
+      {:a 8 :b 2}      {:a '? :b even?} [{:a 8} nil]
 
-    ;;guard clause
-    {:a 2}           {(list :a :when even?) '?}  [{:a 2} nil]
+      ;;guard clause
+      {:a 2}           {(list :a :when even?) '?}  [{:a 2} nil]
 
-    ;;guard with not-found
-    {:a 1}           {(list :a :when even? :not-found 0) '?}  [{:a 0} nil]
+      ;;guard with not-found
+      {:a 1}           {(list :a :when even? :not-found 0) '?}  [{:a 0} nil]
 
-    ;;with option
-    {:a inc}
-    '{(:a :with [3]) ?a}
-    [{:a 4} {'?a 4}]
+      ;;with option
+      {:a inc}
+      '{(:a :with [3]) ?a}
+      [{:a 4} {'?a 4}]
 
-    {:a identity}
-    '{(:a :with [{:b 2 :c 3}]) {:b ?}}
-    [{:a {:b 2}} nil]
+      {:a identity}
+      '{(:a :with [{:b 2 :c 3}]) {:b ?}}
+      [{:a {:b 2}} nil]
 
-    ;;seq query
-    [{:a 1} {:a 2 :b 2} {}]
-    '[{:a ?}]
-    [[{:a 1} {:a 2} {}] nil]
+      ;;seq query
+      [{:a 1} {:a 2 :b 2} {}]
+      '[{:a ?}]
+      [[{:a 1} {:a 2} {}] nil]
 
-    ;;nested map query
-    {:a {:b 1 :c 2}}
-    '{:a {:b ?}}
-    [{:a {:b 1}} nil]
+      ;;nested map query
+      {:a {:b 1 :c 2}}
+      '{:a {:b ?}}
+      [{:a {:b 1}} nil]
 
-    {:a {:b [{:c 1 :d 5} {:c 2}]}}
-    '{:a {:b [{:c ?}]}}
-    [{:a {:b [{:c 1} {:c 2}]}} nil]
+      {:a {:b [{:c 1 :d 5} {:c 2}]}}
+      '{:a {:b [{:c ?}]}}
+      [{:a {:b [{:c 1} {:c 2}]}} nil]
 
-    ;;named variable
-    {:a 1 :b 2}
-    '{:a ?a}
-    [{:a 1} {'?a 1}]
+      ;;named variable
+      {:a 1 :b 2}
+      '{:a ?a}
+      [{:a 1} {'?a 1}]
 
-    ;;named variable join
-    {:a 2 :b {:c 2}}      '{:a ?x :b {:c ?x}} [{:a 2 :b {:c 2}} '{?x 2}]
-    {:a 2 :b 1} '{:a ?x :b ?x} [nil {}]      
+      ;;named variable join
+      {:a 2 :b {:c 2}}      '{:a ?x :b {:c ?x}} [{:a 2 :b {:c 2}} '{?x 2}]
+      {:a 2 :b 1} '{:a ?x :b ?x} [nil {}]
 
 
-    ;;named join
-    {:a 1 :b 1}
-    '{:a ?a :b ?a}
-    [{:a 1 :b 1} {'?a 1}]
+      ;;named join
+      {:a 1 :b 1}
+      '{:a ?a :b ?a}
+      [{:a 1 :b 1} {'?a 1}]
 
-    ;;capture a sequence
-    [{:a 1 :b 2} {:a 3 :b 4 :c 5} {:b 6}]
-    '[{:a ? :b ?} ?g]
-    [[{:a 1 :b 2} {:a 3 :b 4} {:b 6}]
-     {'?g [{:a 1 :b 2} {:a 3 :b 4} {:b 6}]}]
+      ;;capture a sequence
+      [{:a 1 :b 2} {:a 3 :b 4 :c 5} {:b 6}]
+      '[{:a ? :b ?} ?g]
+      [[{:a 1 :b 2} {:a 3 :b 4} {:b 6}]
+       {'?g [{:a 1 :b 2} {:a 3 :b 4} {:b 6}]}]
 
-    ;;seq option
-    (for [x (range 10)]
-      {:a x :b x})
-    '[{:a ? :b ?} ? :seq [2 3]]
-    [[{:a 2 :b 2} {:a 3 :b 3} {:a 4 :b 4}] nil]
+      ;;seq option
+      (for [x (range 10)]
+        {:a x :b x})
+      '[{:a ? :b ?} ? :seq [2 3]]
+      [[{:a 2 :b 2} {:a 3 :b 3} {:a 4 :b 4}] nil]
 
-    ;;batch option
-    {:a identity}
-    '{(:a :batch [[3] [{:ok 1}]]) ?a}
-    [{:a [3 {:ok 1}]} {'?a [3 {:ok 1}]}]
-    ))
+      ;;batch option
+      {:a identity}
+      '{(:a :batch [[3] [{:ok 1}]]) ?a}
+      [{:a [3 {:ok 1}]} {'?a [3 {:ok 1}]}]))
+  
+  (testing "Pattern respects the given data-schema."
+    (is (= [{:a 1} '{?a 1}]
+           (sut/run {:a '?a} [:map [:a :int]] {:a 1}))))
+  (testing "Pattern invalid so returns error."
+    (is (:error (sut/run {:a '?a} [:map [:b :int]] {:a 1})))))


### PR DESCRIPTION
Closes #37, closes #42
---

## Schema

The validation of the pattern is done in 2 steps:

1) general pattern validation: to ensure the pattern format is correct
2) client pattern validation: to ensure the pattern respects the data-schema provided by the client

For 2), some transformation were needed such as:
- removing the options in the keys (`(:a :with [3]) => :a`) to match keys of `data-schema`

The sequence capture and option are supported (`'[{:a ? :b ?}]` or `'[{:a ? :b ?} ? :seq [2 3]]`)

## API

- `run` can now accept an optional `schema` to perform client validation. (the general pattern validation is always done).
- If the pattern is not valid, the error is returned as pure Clojure data.