### PR TITLE
Enable clj-kondo config for local use

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["../resources/clj-kondo.exports/sg.flybot/lasagna-pull"]}

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .nrepl-*
 target/
 .rebel*
-.clj-kondo/
+.cache # clj-kondo and lsp cache
 .lsp/
 .calva/
 docs/


### PR DESCRIPTION
This enables your exported clj-kondo configuration locally as well, such that you won't see lint warnings in e.g. pullable.cljc